### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@TriformAI/pm


### PR DESCRIPTION
I have tried to align of all our repositories in GitHub with respect to naming and how the repo is managed. I have also added four teams: https://github.com/orgs/TriformAI/teams

Each repository has been assigned a team, and the CODEOWNERS in combination with branch protecton rules in the repository settings will require at least one person working closely with the repository (other than the creator of the PR) to review the changes prior to merge.

Administrators can override the branch protection, but it should preferably only be done in the event of an emergency. The purpose of the peer reviews being both quality control and to disseminate knowledge across the team.

Let me know if it causes any issues!